### PR TITLE
Fix capability type encoding in CDDL

### DIFF
--- a/README.md
+++ b/README.md
@@ -617,9 +617,10 @@ dict-type =
 
 capability-type =
     ; cbor-tag-capability-type
-    #6.148([
-        borrow-type: inline-type
-    ])
+    #6.148(
+        ; borrow-type
+        inline-type
+    )
 
 type-ref =
     ; cbor-tag-type-ref


### PR DESCRIPTION
Fix `capability-type` encoding in CDDL by changing it from array to single data item.

Closes #23