### PR TITLE
Add more types and reassign tag numbers in CDDL

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -594,13 +594,16 @@ ccf-composite-type-message =
         )
     ])
 
-type-id = (
-    id: bstr,
-    location-identifier: tstr,
-)
+; id is a unique identifier used by CCF to associate composite/interface type information
+; with value through type-ref and type-value-ref.
+id = bstr
+
+; cadence-type-id is an identifier used by Cadence to identify types.
+cadence-type-id = tstr
 
 composite-type = [
-    type-id
+    id: id,
+    cadence-type-id: cadence-type-id,
     fields: [
         + [
             field-name: tstr,
@@ -610,7 +613,8 @@ composite-type = [
 ]
 
 interface-type = [
-    type-id
+    id: id,
+    cadence-type-id: tstr,
 ]
 
 struct-type =
@@ -706,10 +710,7 @@ capability-type =
 
 type-ref =
     ; cbor-tag-type-ref
-    #6.136(
-        ; type-id
-        bstr
-    )
+    #6.136(id)
 
 ; simple-type-id is an enumeration.
 simple-type-id = &(
@@ -952,9 +953,10 @@ contract-interface-type-value =
     #6.226(composite-type-value)
 
 composite-type-value = [
+    id: id,
+    cadence-type-id: cadence-type-id,
+    ; type is only used by enum type value
     type: nil / type-value,
-    id: bstr,
-    location-identifier: tstr,
     fields: [
         + [
             name: tstr,
@@ -977,7 +979,7 @@ function-type-value =
     #6.193(function-untagged-type-value)
 
 function-untagged-type-value = [
-    id: tstr,
+    cadence-type-id: cadence-type-id,
     parameters: [
         * [
             label: tstr,
@@ -998,7 +1000,7 @@ reference-type-value =
 restricted-type-value =
     ; cbor-tag-restricted-type-value
     #6.191([
-      id: tstr,
+      cadence-type-id: cadence-type-id,
       type: type-value,
       restrictions: [+ type-value]
     ])
@@ -1013,10 +1015,7 @@ capability-type-value =
 
 type-value-ref =
     ; cbor-tag-type-value-ref
-    #6.184(
-        ; composite-type-value-id
-        bstr
-    )
+    #6.184(id)
 
 ;CDDL-END
 ```

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -594,13 +594,13 @@ ccf-composite-type-message =
         )
     ])
 
-composite-type-id = (
+type-id = (
     id: bstr,
     location-identifier: tstr,
 )
 
 composite-type = [
-    composite-type-id
+    type-id
     fields: [
         + [
             field-name: tstr,
@@ -610,7 +610,7 @@ composite-type = [
 ]
 
 composite-interface-type = [
-    composite-type-id
+    type-id
 ]
 
 struct-type =
@@ -707,7 +707,7 @@ capability-type =
 type-ref =
     ; cbor-tag-type-ref
     #6.136(
-        ; composite-type-id
+        ; type-id
         bstr
     )
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -609,7 +609,7 @@ composite-type = [
     ]
 ]
 
-composite-interface-type = [
+interface-type = [
     type-id
 ]
 
@@ -635,15 +635,15 @@ enum-type =
 
 struct-interface-type =
     ; cbor-tag-struct-interface-type
-    #6.176(composite-interface-type)
+    #6.176(interface-type)
 
 resource-interface-type =
     ; cbor-tag-resource-interface-type
-    #6.177(composite-interface-type)
+    #6.177(interface-type)
 
 contract-interface-type =
     ; cbor-tag-contract-interface-type
-    #6.178(composite-interface-type)
+    #6.178(interface-type)
 
 inline-type =
     simple-type


### PR DESCRIPTION
Closes #34

Added these type objects in CDDL:
- struct interface type
- resource interface type
- contract interface type
- reference type
- restricted type

Added interface types as options to ccf-composite-type-message.

Added reference and restricted types as options to inline-type.

Added support for function value.

Refactored CDDL to separate type objects from type value objects for readability and cleaner implementation.

Reassigned tag numbers to reserve some tag numbers in each (sub)group.  The following groups have assigned and reserved tag numbers [128, 255]:
- root objects:  2 of 8 are assigned
- types
  - inline: 9 of 24 are assigned
  - composite: 5 of 16 are assigned
  - interface: 3 of 8 are assigned  
- type values
  - non-composite and non-interface: 10 of 24 are assigned
  - composite: 5 of 16 are assigned
  - interface: 3 of 8 are assigned

Unassigned tag numbers within each group are reserved for that group.  In addition, there are 24 reserved tag numbers that are not associated with any existing groups [232, 255].
