### PR TITLE
Update Status, Timeline, Next Steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,15 +17,22 @@ RFC 8949 and RFC 8610 are [Internet Standards](https://en.wikipedia.org/wiki/Int
 
 ## Status
 
-CCF is currently a DRAFT.  More content is being added to turn the abridged draft into full draft.
+- CCF specification is currently an ABRIDGED DRAFT with work underway to specify canonical encoding.
+- CCF codec currently implements CCF specs revision [20221212a](https://github.com/fxamacker/ccf_draft/blob/aaca94b2478b821b92db155cbce32ff2554f4f95/ccf_specs.md). The CCF codec will be submitted as a PR to onflow/cadence once it's ready for review.
 
-Additional content includes a section on canonical encoding, additional Cadence type(s), and more CCF examples.  Some changes to Cadence may be required, such as https://github.com/onflow/cadence/issues/2167 to add static type for `cadence.Link`.
+### Next steps
+
+More content is being added to turn the abridged draft into full draft.  For example, a section on canonical encoding, additional Cadence type(s), and more CCF examples.  Some changes to Cadence may be required, such as https://github.com/onflow/cadence/issues/2167 to add static type for `cadence.PathLink` (aka `cadence.Link` in old docs).
 
 ## Timeline
 - Oct 18, 2022 - Resume onboarding of Cadence external value encoding and requirements.
 - Nov 17, 2022 - Share the abridged first draft of CCF with Cadence team and Ramtin for initial sanity check.
 - Nov 22, 2022 - First team meeting about abridged draft of CCF to present and discuss revision [20221122b](https://github.com/fxamacker/ccf_draft/blob/2594c4859e51715bb9e770cc42542eb31278cfc4/README.md).
 - Nov 29, 2022 - Second team meeting about draft of CCF to present and discuss revision [20221129b](https://github.com/fxamacker/ccf_draft/blob/2c9541a90de968413ec34d31dcf2444949dbce1e/ccf_specs.md).
+- Dec 9, 2022 - Merged [PR 35](https://github.com/fxamacker/ccf_draft/pull/35) to add more Cadence types and reassign CBOR tag values. The only Cadence type that is known to be missing from CCF specs is `cadence.PathLink` (blocked by https://github.com/onflow/cadence/issues/2167).
+- Dec 15, 2022 - Updated CCF codec (WIP) to incorporate latest CCF specs.  For example, updates to CCF specs from PRs [30](https://github.com/fxamacker/ccf_draft/pull/30), [31](https://github.com/fxamacker/ccf_draft/pull/31), [32](https://github.com/fxamacker/ccf_draft/pull/32), and [35](https://github.com/fxamacker/ccf_draft/pull/35).  All existing CCF codec tests pass (e.g. JSON-Cadence tests ported and modified to CCF).
+
+:point_right:  CCF codec passing JSON-Cadence tests ported and modified to CCF was an important milestone.  However, more CCF tests are needed because CCF has more features and encodes more information than JSON-Cadence Data Interchange Format.  Additionally, the CCF codec will need to be fuzz tested by the Cadence team before it is used in production.
 
 ## Preliminary Size and Benchmark Comparisons
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ RFC 8949 and RFC 8610 are [Internet Standards](https://en.wikipedia.org/wiki/Int
 
 More content is being added to turn the abridged draft into full draft.  For example, a section on canonical encoding, additional Cadence type(s), and more CCF examples.  Some changes to Cadence may be required, such as https://github.com/onflow/cadence/issues/2167 to add static type for `cadence.PathLink` (aka `cadence.Link` in old docs).
 
+:point_right:  CCF codec passing JSON-Cadence tests ported and modified to CCF was an important milestone.  However, more CCF tests are needed because CCF has more features and encodes more information than JSON-Cadence Data Interchange Format.  Additionally, the CCF codec will need to be fuzz tested by the Cadence team before it is used in production.
+
 ## Timeline
 - Oct 18, 2022 - Resume onboarding of Cadence external value encoding and requirements.
 - Nov 17, 2022 - Share the abridged first draft of CCF with Cadence team and Ramtin for initial sanity check.
@@ -31,8 +33,6 @@ More content is being added to turn the abridged draft into full draft.  For exa
 - Nov 29, 2022 - Second team meeting about draft of CCF to present and discuss revision [20221129b](https://github.com/fxamacker/ccf_draft/blob/2c9541a90de968413ec34d31dcf2444949dbce1e/ccf_specs.md).
 - Dec 9, 2022 - Merged [PR 35](https://github.com/fxamacker/ccf_draft/pull/35) to add more Cadence types and reassign CBOR tag values. The only Cadence type that is known to be missing from CCF specs is `cadence.PathLink` (blocked by https://github.com/onflow/cadence/issues/2167).
 - Dec 15, 2022 - Updated CCF codec (WIP) to incorporate latest CCF specs.  For example, updates to CCF specs from PRs [30](https://github.com/fxamacker/ccf_draft/pull/30), [31](https://github.com/fxamacker/ccf_draft/pull/31), [32](https://github.com/fxamacker/ccf_draft/pull/32), and [35](https://github.com/fxamacker/ccf_draft/pull/35).  All existing CCF codec tests pass (e.g. JSON-Cadence tests ported and modified to CCF).
-
-:point_right:  CCF codec passing JSON-Cadence tests ported and modified to CCF was an important milestone.  However, more CCF tests are needed because CCF has more features and encodes more information than JSON-Cadence Data Interchange Format.  Additionally, the CCF codec will need to be fuzz tested by the Cadence team before it is used in production.
 
 ## Preliminary Size and Benchmark Comparisons
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -134,7 +134,7 @@ CBOR defines data [well-formedness](https://www.rfc-editor.org/rfc/rfc8949.html#
 
 CCF message validation should be done after passing checks for well-formedness.  Invalid CCF messages should be rejected.
 
-CCF decoder should detect and reject malformed or malicious data before creating Cadence objects.  Check for well-formedness can be done on other node types without asking EN for the Cadence type info.
+CCF decoder should detect and reject malformed or malicious data before creating Cadence objects and without requiring Cadence type info.
 
 ## CCF Examples
 


### PR DESCRIPTION
Update README:
- Provide separate status of CCF specs and CCF codec.
- Update Timeline to include milestones reached on Dec 9 and Dec 15.
- Add Next Steps under Status.
- Add note about more tests being required even though CCF codec passed all ported tests from JSON-Cadence Data Interchange Format.
- Add note about CCF codec eventually needing fuzz tests by the Cadence team before being used in production.