### PR TITLE
Specify requirements for Valid and Deterministic Encodings

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -195,6 +195,8 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 - CBOR data items MUST be well-formed and valid as defined in RFC 8949.  E.g. CBOR text strings MUST contain valid UTF-8.  As an exception, RFC 8949 requirements for CBOR maps are not applicable because CCF does not use CBOR maps.
 
+- CCF encodings must comply with specifications in "CCF Specified in CDDL Notation" section of this document.
+
 - `composite-type.id` MUST be unique in `ccf-typedef-message` or `ccf-typedef-and-value-message`.
 
 - `composite-type.cadence-type-id` MUST be unique in `ccf-typedef-message` or `ccf-typedef-and-value-message`.

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -177,6 +177,8 @@ CCF encoding decouples value encoding from type encoding.  For example:
 - Cadence booleans is encoded as a tuple of type and value: the `Bool` type and its value.  
 - Cadence strings is encoded as a tuple of type and value: the `String` type and its value.
 
+For compactness, encoders can omit encodings of Cadence type when Cadence optional value is nil, provided that the type information is encoded in the outer container.
+
 For compactness, CCF encoding skips type encoding when type can be inferred.
 
 As one example, the type of each element in `[String]` can be inferred to have type `String`.  Given this, CCF encodings of `[String]` can skip encoding each element's type of `String`.  Instead, CCF encodes `[String]` as a tuple like this: `[String]` type and a value representing a list of element values.  This avoids redundantly encoding each element's type.
@@ -239,7 +241,7 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
 
 - `composite-type-value.id` MUST be identical to the zero-based encoding order `type-value`.
 
-- `inline-type-and-value` MUST NOT be used when type can be inferred.
+- `inline-type-and-value` MUST NOT be used when type can be omitted as described in "Cadence Types and Values Encoding".
 
 - The following data items MUST be sorted using bytewise lexicographic order of their deterministic encodings:
   - Type definitions MUST be sorted by `cadence-type-id` in `composite-typedef`.

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -223,7 +223,9 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 A CCF encoding is deterministic if it satisfies the "Deterministic CCF Encoding Requirements".
 
-Encoders SHOULD emit CCF encodings that are deterministic.  CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings.
+Encoders SHOULD emit CCF encodings that are deterministic.  CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings.  For example:
+- a CCF-based protocol for encoding transaction arguments might want to specify that encoders MUST produce deterministic encodings of the values.
+- a CCF-based protocol for encoding script results might want to specify that encoders are not required to produce deterministic encodings of the values (if results are sent to clients that don't care about the values being deterministically encoded). 
 
 Decoders SHOULD check CCF encodings to determine whether they are deterministic encodings.  CCF-based protocols MUST specify when decoders are required to check for deterministic encodings and how to handle nondeterministic encodings.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -207,9 +207,9 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 - `type-value-ref.id` MUST refer to `composite-type-value.id` in the same `composite-type-value` data item.
 
-- `name` MUST be unique in `composite-type-value.fields`.
-
-- `identifier` MUST be unique in `composite-type-value.initializers`.
+- all parameter lists MUST be unique in `composite-type-value`.
+  - `name` MUST be unique in `composite-type-value.fields`. 
+  - `identifier` MUST be unique in `composite-type-value.initializers`.
 
 - `restricted-type.restrictions` MUST be unique.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -1,7 +1,7 @@
 # DRAFT - Cadence Compact Format (CCF)
 
 Author: Faye Amacker  
-Status: ABRIDGED DRAFT  
+Status: DRAFT  
 Date: Feb 13, 2023  
 Revision: 20230213a
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,8 +2,8 @@
 
 Author: Faye Amacker  
 Status: DRAFT  
-Date: Feb 14, 2023  
-Revision: 20230214a
+Date: Feb 16, 2023  
+Revision: 20230216a
 
 ## Abstract
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -209,9 +209,11 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 - `type-value-ref.id` MUST refer to `composite-type-value.id` in the same `composite-type-value` data item.
 
-- all parameter lists MUST be unique in `composite-type-value`.
-  - `name` MUST be unique in `composite-type-value.fields`. 
-  - `identifier` MUST be unique in `composite-type-value.initializers`.
+- `name` MUST be unique in `composite-type-value.fields`. 
+  
+- All parameter lists MUST have unique `identifier`. For example, `indentifier` MUST be unique in
+  - `composite-type-value.initializers`
+  - `function-value.parameters`
 
 - elements MUST be unique in `restricted-type` or `restricted-type-value`.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -211,7 +211,7 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
   - `name` MUST be unique in `composite-type-value.fields`. 
   - `identifier` MUST be unique in `composite-type-value.initializers`.
 
-- `restricted-type.restrictions` MUST be unique.
+- Elements of `restricted-type.restrictions` MUST be unique.
 
 - `field-name` MUST be unique in `composite-type`.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -243,7 +243,8 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
   - `composite-type.fields` MUST be sorted by `name`
   - `composite-type-value.fields` MUST be sorted by `name`.
   - `composite-type-value.initializers` MUST be sorted by `identifier`.
-  - `restricted-type.restrictions` MUST be sorted.
+  - `restricted-type.restrictions` MUST be sorted by restriction's `cadence-type-id`.
+  - `restricted-type-value.restrictions` MUST be sorted by restriction's `cadence-type-id`.
 
 ## Security Considerations
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -201,6 +201,8 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 - `composite-type.cadence-type-id` MUST be unique in `ccf-typedef-message` or `ccf-typedef-and-value-message`.
 
+- `field-name` MUST be unique in `composite-type`.
+
 - `type-ref.id` MUST refer to `composite-type.id`.
 
 - `composite-type-value.id` MUST be unique in the same `composite-type-value` data item.
@@ -211,9 +213,7 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
   - `name` MUST be unique in `composite-type-value.fields`. 
   - `identifier` MUST be unique in `composite-type-value.initializers`.
 
-- Elements of `restricted-type.restrictions` MUST be unique.
-
-- `field-name` MUST be unique in `composite-type`.
+- elements MUST be unique in `restricted-type` or `restricted-type-value`.
 
 - keys MUST be unique in `dict-value`.  Decoders are not always required to check for duplicate dictionary keys.  In some cases, checking for duplicate dictionary key is not necessary or it may be delegated to the application.
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -215,9 +215,9 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
   - `composite-type-value.initializers`
   - `function-value.parameters`
 
-- elements MUST be unique in `restricted-type` or `restricted-type-value`.
+- Elements MUST be unique in `restricted-type` or `restricted-type-value`.
 
-- keys MUST be unique in `dict-value`.  Decoders are not always required to check for duplicate dictionary keys.  In some cases, checking for duplicate dictionary key is not necessary or it may be delegated to the application.
+- Keys MUST be unique in `dict-value`.  Decoders are not always required to check for duplicate dictionary keys.  In some cases, checking for duplicate dictionary key is not necessary or it may be delegated to the application.
 
 ### Deterministic CCF Encoding Requirements
 
@@ -240,7 +240,7 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
 - `inline-type-and-value` MUST NOT be used when type can be inferred.
 
 - The following data items MUST be sorted using bytewise lexicographic order of their deterministic encodings:
-  - type definitions MUST be sorted by `cadence-type-id` in `composite-typedef`.
+  - Type definitions MUST be sorted by `cadence-type-id` in `composite-typedef`.
   - `dict-value` key-value pairs MUST be sorted by key.
   - `composite-type.fields` MUST be sorted by `name`
   - `composite-type-value.fields` MUST be sorted by `name`.

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,8 +2,8 @@
 
 Author: Faye Amacker  
 Status: DRAFT  
-Date: Feb 13, 2023  
-Revision: 20230213a
+Date: Feb 14, 2023  
+Revision: 20230214a
 
 ## Abstract
 
@@ -165,6 +165,24 @@ This specification uses CDDL notation to express CBOR data items:
 
 CCF is a data format that uses a subset of CBOR with additional requirements for validity and deterministic encoding.
 
+### Cadence Types and Values Encoding
+
+[Cadence values have types](https://developers.flow.com/cadence/language/values-and-types).  For example:
+- `true` has the type `Bool` 
+- `"hello"` has the type `String` 
+- `let aos: [String] = ["hello", "world"]` declares `aos` of type `[String]`. 
+- `let aoa: [AnyStruct] = ["hello", true]` declares `aoa` of type `[AnyStruct]`.
+
+CCF encoding decouples value encoding from type encoding.  For example:  
+- Cadence booleans is encoded as a tuple of type and value: the `Bool` type and its value.  
+- Cadence strings is encoded as a tuple of type and value: the `String` type and its value.
+
+For compactness, CCF encoding skips type encoding when type can be inferred.
+
+As one example, the type of each element in `[String]` can be inferred to have type `String`.  Given this, CCF encodings of `[String]` can skip encoding each element's type of `String`.  Instead, CCF encodes `[String]` as a tuple like this: `[String]` type and a value representing a list of element values.  This avoids redundantly encoding each element's type.
+
+If type cannot be inferred, it must be encoded as part of a tuple representing a type and its value.  For example, the type of each element in `[AnyStruct]` cannot be inferred.  The type `AnyStruct` is the top type of all non-resource types and array elements can be of heterogenous types. In this case, `[AnyStruct]` is encoded as a tuple like this: `[AnyStruct]` type and a value being a list of tuples representing each element's type and value.
+
 ### Valid CCF Encoding Requirements
 
 A CCF encoding is valid if it complies with "Valid CCF Encoding Requirements".
@@ -215,11 +233,7 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
 
 - `composite-type-value.id` MUST be identical to the zero-based encoding order `type-value`.
 
-- `inline-type-and-value` MUST NOT be used when type can be deduced, for instance:
-  - array elements MUST use `inline-type-and-value` if array type is `[AnyStruct]`.
-  - array elements MUST NOT use `inline-type-and-value` if array type is `[Int]`.
-  - dictionay keys MUST NOT use `inline-type-and-value` while elements must, if dictionary type is `{String: AnyStruct}`.
-  - composite field MUST NOT use `inline-type-and-value` if that field type is `Int`.
+- `inline-type-and-value` MUST NOT be used when type can be inferred.
 
 - The following data items MUST be sorted using bytewise lexicographic order of their deterministic encodings:
   - type definitions MUST be sorted by `cadence-type-id` in `composite-typedef`.

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -177,13 +177,13 @@ CCF encoding decouples value encoding from type encoding.  For example:
 - Cadence booleans is encoded as a tuple of type and value: the `Bool` type and its value.  
 - Cadence strings is encoded as a tuple of type and value: the `String` type and its value.
 
-For compactness, encoders can omit encodings of Cadence type when Cadence optional value is nil, provided that the type information is encoded in the outer container.
+For compactness, encoders can omit encodings of Cadence type when:
+- Optional value is nil, provided that the optional type information is encoded in the outer container.
+- Element's type matches the outer container's element type.
 
-For compactness, CCF encoding skips type encoding when type can be inferred.
-
-As one example, the type of each element in `[String]` can be inferred to have type `String`.  Given this, CCF encodings of `[String]` can skip encoding each element's type of `String`.  Instead, CCF encodes `[String]` as a tuple like this: `[String]` type and a value representing a list of element values.  This avoids redundantly encoding each element's type.
-
-If type cannot be inferred, it must be encoded as part of a tuple representing a type and its value.  For example, the type of each element in `[AnyStruct]` cannot be inferred.  The type `AnyStruct` is the top type of all non-resource types and array elements can be of heterogenous types. In this case, `[AnyStruct]` is encoded as a tuple like this: `[AnyStruct]` type and a value being a list of tuples representing each element's type and value.
+For example, when encoding a Cadence container such as `Array`:
+- `[String]`: each element's type matches the outer container's element type, so encoders can omit encoding each element's type.
+- `[AnyStruct]`: each element's type cannot match the outer container's element type, so encoders must encode the type for each element.
 
 ### Valid CCF Encoding Requirements
 


### PR DESCRIPTION
Add Serialization Considerations section and specify
- Valid CCF Encoding Requirements
- Deterministic CCF Encoding Requirements

Replace "ABRIDGED DRAFT" with "DRAFT" in Status of this Document section.

These requirements are necessary and have an impact on CCF codec speed and memory use.

Prior formats (JSON-Cadence Data Interchange and CBF) didn't specify requirements for validity or deterministic encoding.  Updated benchmark comparisons (coming soon) should be viewed with this in mind.   For example, sorting (as part of deterministic encoding) isn't free.