### PR TITLE
Remove unnecessary cadence-type-id

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -822,7 +822,6 @@ reference-type =
 restricted-type =
     ; cbor-tag-restricted-type
     #6.143([
-      cadence-type-id: cadence-type-id,
       type: inline-type,
       restrictions: [* inline-type]
     ])
@@ -996,7 +995,6 @@ fix64-value = (int .ge -9223372036854775808) .le 9223372036854775807
 ufix64-value = uint .le 18446744073709551615
 
 function-value = [
-    cadence-type-id: cadence-type-id,
     parameters: [
         * [
             label: tstr,
@@ -1122,7 +1120,6 @@ reference-type-value =
 restricted-type-value =
     ; cbor-tag-restricted-type-value
     #6.191([
-      cadence-type-id: cadence-type-id,
       type: type-value,
       restrictions: [* type-value]
     ])


### PR DESCRIPTION
### Description

In JSON-CDC, sometimes cadence-type-id was encoded when it was just a "stringification" of other encoded data and not necessary to encode.

In CCF, we don't need to keep this inefficiency for the sake of compatibility.

Thanks @turbolent for spotting this!

### Changes

Removed the inefficiency by removing unnecessary cadence-type-id from
- restricted-type-value
- restricted-type
- function-value

Closes #68 