### PR TITLE
Improve `function-value`

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -997,12 +997,12 @@ function-value = [
     type-parameters: [
         * [
            name: tstr,
-           ? type-bound: type-value
+           type-bound: type-value / nil
         ]
     ]
     parameters: [
         * [
-            ? label: tstr,
+            label: tstr,
             identifier: tstr,
             type: type-value
         ]

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -997,12 +997,12 @@ function-value = [
     type-parameters: [
         * [
            name: tstr,
-           type-bound: type-value 
+           ? type-bound: type-value
         ]
     ]
     parameters: [
         * [
-            label: tstr,
+            ? label: tstr,
             identifier: tstr,
             type: type-value
         ]


### PR DESCRIPTION
- Type parameter type bounds are optional
- Parameter argument labels are optional: they should be encoded as empty string if not given