### PR TITLE
Remove nullable type-value and explicitly specify

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,8 +2,8 @@
 
 Author: Faye Amacker  
 Status: RC1  
-Date: March 14, 2023  
-Revision: 20230314a
+Date: April 3, 2023  
+Revision: 20230403a
 
 ## Abstract
 
@@ -213,6 +213,8 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 - `name` MUST be unique in `composite-type-value.fields`. 
   
+- `name` MUST be unique in `function-value.type-parameters`. 
+
 - All parameter lists MUST have unique `identifier`. For example, `indentifier` MUST be unique in
   - `composite-type-value.initializers`
   - `function-value.parameters`
@@ -1011,7 +1013,6 @@ function-value = [
 ]
 
 type-value =
-    nil
     / simple-type-value
     / optional-type-value
     / varsized-array-type-value
@@ -1125,7 +1126,7 @@ reference-type-value =
 restricted-type-value =
     ; cbor-tag-restricted-type-value
     #6.191([
-      type: type-value,
+      type: type-value / nil,
       restrictions: [* type-value]
     ])
 
@@ -1134,7 +1135,7 @@ capability-type-value =
     ; use an array as an extension point
     #6.192([
       ; borrow-type
-      type-value
+      type-value / nil
     ])
 
 type-value-ref =

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -1012,8 +1012,7 @@ function-value = [
     return-type: type-value
 ]
 
-type-value =
-    / simple-type-value
+type-value = simple-type-value
     / optional-type-value
     / varsized-array-type-value
     / constsized-array-type-value


### PR DESCRIPTION
We now explicitly specify nullable types starting with PR #75.  

- Remove null as an option for type-value.

- Specify null as an option for capability-type-value and restricted-type-value.

- Add valid requirement for unique name in function-type.type-parameters.

Thanks @turbolent for great suggestions during our discussions on Slack and for opening PR 75!

Closes #76 