### PR TITLE
Update text about fxamacker/cbor (CBOR codec)

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -120,7 +120,10 @@ High quality CBOR codecs are available in various programming languages.
 
 In JavaScript, there are multiple CBOR codecs that are actively maintained. As one example, [hildjj/node-cbor](https://github.com/hildjj/node-cbor) is  maintained by Joe Hildebrand (former VP of Engineering at Mozilla and Distinguished Engineer at Cisco). It's a monorepo with several packages including a "cbor package compiled for use on the web, including all of its non-optional dependencies".
 
-In Go, [fxamacker/cbor](https://github.com/fxamacker/cbor) is a fuzz-tested CBOR codec [already used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.  It's fast, easy to use, and passed multiple security assessments this year without known problems. It is used by Arm Ltd., Chainlink, ConsenSys, Dapper Labs, Duo Labs (cisco), EdgeX Foundry, Microsoft, Mozilla, Oasis Labs, Tailscale, Taurus SA, and many others.  GitHub reports fxamacker/cbor/v2 is used by over 1275 repositories.
+In Go, [fxamacker/cbor](https://github.com/fxamacker/cbor) is used by Cadence in its [CCF codec](https://github.com/onflow/cadence/tree/master/encoding/ccf):
+  - fxamacker/cbor was [already used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.
+  - fxamacker/cbor was designed with security in mind and passed multiple security assessments in 2022.  A [nonconfidential security assessment](https://github.com/veraison/go-cose/blob/v1.0.0-rc.1/reports/NCC_Microsoft-go-cose-Report_2022-05-26_v1.0.pdf) produced by NCC Group for Microsoft Corporation includes parts of fxamacker/cbor.
+  - fxamacker/cbor is used by Arm Ltd., Chainlink, ConsenSys, Dapper Labs, Duo Labs (Cisco), EdgeX Foundry, F5, Fraunhofer AISEC, Microsoft, Mozilla, Oasis Labs, Tailscale, Taurus SA, TIBCO, and others.  As of April 2023, GitHub reports fxamacker/cbor is used by over 2,000 repositories (1,900+ using v2 and 195+ using v1).
 
 ### Terminology
 


### PR DESCRIPTION
Update Why CBOR section's mention of fxamacker/cbor:
- Remove adjectives about it.
- Mention and link to [CCF codec in Cadence](https://github.com/onflow/cadence/tree/master/encoding/ccf).
- Mention and link to a [nonconfidential security assessment](https://github.com/veraison/go-cose/blob/v1.0.0-rc.1/reports/NCC_Microsoft-go-cose-Report_2022-05-26_v1.0.pdf) (NCC Group for Microsoft Corporation).
- Update usage stats because GitHub shows stats for v1 (obsolete version nobody should be using anymore).