### PR TITLE
Update status from "RC2 DRAFT" to "RC2"

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -116,7 +116,7 @@ Other considerations for using CBOR include availability and quality of CBOR cod
 
 ### Interoperability and Reuse of CBOR Codecs
 
-Widely used CBOR codecs are available in various programming languages.
+Widely used CBOR codecs are available in various programming languages.  CCF codecs can reuse existing CBOR codecs to reduce risks.
 
 In JavaScript, there are multiple widely used CBOR codecs. As one example, [hildjj/node-cbor](https://github.com/hildjj/node-cbor) is  maintained by Joe Hildebrand (former VP of Engineering at Mozilla and Distinguished Engineer at Cisco). It's a monorepo with several packages including a "cbor package compiled for use on the web, including all of its non-optional dependencies".
 
@@ -125,9 +125,9 @@ In C, Intel maintains [TinyCBOR](https://github.com/intel/tinycbor), a CBOR code
 For .NET languages, Microsoft maintains [System.Formats.Cbor namespace](https://learn.microsoft.com/en-us/dotnet/api/system.formats.cbor), which is the CBOR codec in .Net Platform Extensions.
 
 In Go, [fxamacker/cbor](https://github.com/fxamacker/cbor) is used by Cadence in its [CCF codec](https://github.com/onflow/cadence/tree/master/encoding/ccf):
-  - fxamacker/cbor was [already used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.
   - fxamacker/cbor was designed with security in mind and passed multiple security assessments in 2022.  A [nonconfidential security assessment](https://github.com/veraison/go-cose/blob/v1.0.0-rc.1/reports/NCC_Microsoft-go-cose-Report_2022-05-26_v1.0.pdf) produced by NCC Group for Microsoft Corporation includes parts of fxamacker/cbor.
   - fxamacker/cbor is used by Arm Ltd., Chainlink, Cisco, ConsenSys, Dapper Labs, EdgeX Foundry, F5, Fraunhofer-AISEC, Microsoft, Mozilla, Oasis Labs, Tailscale, Taurus SA, Teleport, TIBCO, and others.  GitHub reports fxamacker/cbor is used by over 2,000 repositories (2,000+ using v2 and 195+ using v1).
+  - fxamacker/cbor is [used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.
 
 ### Terminology
 

--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -1,9 +1,9 @@
 # Cadence Compact Format (CCF)
 
 Author: Faye Amacker  
-Status: RC2 DRAFT  
-Date: August 3, 2023  
-Revision: 20230803b
+Status: RC2  
+Date: August 4, 2023  
+Revision: 20230804a
 
 ## Abstract
 
@@ -19,7 +19,7 @@ CCF obsoletes [JSON-Cadence Data Interchange Format](https://developers.flow.com
 
 ## Status of this Document
 
-This document is a release candidate (RC2 DRAFT).
+This document is a release candidate (RC2).
 
 ## Copyright Notice
 


### PR DESCRIPTION
Updates #92 

This is mostly to avoid confusion by bumping revision to 20230804a which was missed in prior PR.

While at it, add a sentence to "Interoperabilitty and Reuse of CBOR Codecs".