### PR TITLE
Sync with onflow/ccf unmerged PR 7 commit 6703acb

### DIFF
--- a/ccf_specs.md
+++ b/ccf_specs.md
@@ -2,7 +2,7 @@
 
 Author: Faye Amacker  
 Version: 1.0.0  
-Date: January 26, 2025  
+Date: March 27, 2025
 
 ## Abstract
 
@@ -26,53 +26,55 @@ This document specifies Cadence Compact Format.
 
 Some requirements defined in this document are explicitly specified as optional.  
 
-It is outside the scope of this document to specify individual CCF-based formats or protocols (e.g. events).  For example, CCF-based formats or protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements".
+It is outside the scope of this document to specify individual CCF-based formats or protocols (e.g., events).  For example, CCF-based formats or protocols MUST specify when encoders are required to emit CCF encodings that satisfy "Deterministic CCF Encoding Requirements."
+
+This document does not specify how to encode version numbers of CCF itself, CCF-based formats, or CCF-based protocols.  CCF-based formats and protocols can specify an encoding that uses CalVer, SemVer, sequence-based versioning, any other versioning, or no versioning.  Some CCF-based formats or protocols may want to use CBOR Sequences ([RFC 8742](https://www.rfc-editor.org/rfc/rfc8742.html)) to provide a version number in the first CBOR data item, followed by CBOR data item(s) encoded in CCF.
 
 ## Introduction
 
 CCF is a data format that allows compact, efficient, and deterministic encoding of Cadence external values.
 
-Cadence external values (e.g. events, transaction arguments, etc.) have been encoded using JSON-CDC, which is inefficient, verbose, and doesn't define deterministic encoding.
+Cadence external values (e.g., events, transaction arguments, etc.) have been encoded using JSON-CDC, which is inefficient, verbose, and doesn't define deterministic encoding.
 
 The same `FeesDeducted` event on the Flow blockchain can encode to:
 - 298 bytes in JSON-CDC (minified).
 - 118 bytes in CCF (fully self-describing mode).
 - &nbsp;20 bytes in CCF (partially self-describing mode).
 
-CCF defines all requirements for deterministic encoding (sort orders, smallest encoded forms, and Cadence-specific requirements) to allow CCF codecs implemented in different programming languages to produce the same deterministic encodings.
+CCF defines all requirements for deterministic encoding (sort orders, shortest forms, and Cadence-specific requirements) to allow CCF codecs implemented in different programming languages to produce the same deterministic encodings.
 
-Some requirements (such as "Deterministic CCF Encoding Requirements") are defined as optional. Each CCF-based format or protocol can have its specification state how CCF options are used. This allows each protocol to balance trade-offs such as compatibility, determinism, speed, encoded data size, etc.
+Some requirements (such as "Deterministic CCF Encoding Requirements") are defined as optional. The specification of each CCF-based format or protocol can specify how CCF options are used. This allows each protocol to balance trade-offs such as compatibility, determinism, speed, encoded data size, etc.
 
-CCF uses CBOR and is designed to allow efficient detection and rejection of malformed messages without creating Cadence objects. This allows more costly checks for validity, etc. to be performed only on well-formed messages.
+CCF uses CBOR to efficiently detect and reject malformed messages without creating Cadence objects. This allows more costly checks for validity, etc., to be performed only on well-formed messages.
 
-CBOR is an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) defined by [IETF&nbsp;STD&nbsp;94](https://www.rfc-editor.org/info/std94). CBOR is designed to be relevant for decades and is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), C-DNS&nbsp;([IETF&nbsp;RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([IETF&nbsp;RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
+CBOR is a binary data format specified by [RFC 8949](https://www.rfc-editor.org/info/std94) and designated by IETF as an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) (STD&nbsp;94). CBOR is designed to be relevant for decades and is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
 
 ### Objectives
 
 The goal of CCF is to provide compact, efficient, and deterministic encoding of Cadence external values. To achieve this:
-- CCF uses CBOR's data model with [Preferred Serialization](https://www.rfc-editor.org/rfc/rfc8949.html#name-preferred-serialization) to deterministically encode values to their smallest form.
+- CCF uses CBOR's data model with [Preferred Serialization](https://www.rfc-editor.org/rfc/rfc8949.html#name-preferred-serialization) to deterministically encode values to their shortest form.
 
 - CCF separates Cadence type encoding from Cadence value encoding. This has two distinct advantages:
 
-  - More compact encoding. Cadence type info is not repeatedly encoded unnecessarily in a message. E.g. for a homogeneous array of a Cadence composite type, each element will not have its Cadence composite type info encoded repeatedly.
+  - More compact encoding. Cadence type information is not repeatedly encoded unnecessarily in a message. For example, for a homogeneous array of a Cadence composite type, each element will not have its Cadence composite type information encoded repeatedly.
 
-  - Detachable Cadence type info. Although Cadence type info is required for decoding, CCF-based protocols can send a message's type info once instead of repeatedly sending it to the same client for all messages of that type.
+  - Detachable Cadence type information. Although Cadence type information is required for decoding, CCF-based protocols can send a message's type information once instead of repeatedly sending it to the same client for all messages of that type.
 
 CCF is designed to support:
 
 - All current and future Cadence types, including composite types. CCF supports schemaless encoding and is extensible for new Cadence types.
 
 - Compact encoding. Smaller encoded size is produced by:
-  - CBOR's data model with CBOR Preferred Serialization, which produces more compact encoding than JSON.
-  - Separate encoding of Cadence types and values to avoid repeatedly encoding the same Cadence type info unnecessarily.
+  - CBOR's data model with CBOR Preferred Serialization (more compact encoding of CBOR data items).
+  - Separate encoding of Cadence types and values to avoid repeatedly encoding the same Cadence type information unnecessarily.
 
-- Compact communications. Detachable Cadence type info allows CCF-based protocols to optionally avoid resending the same Cadence type info for all messages matching that type. CCF-based protocols can cache and uniquely identify a Cadence type so it can be matched to Cadence value (such as an event) during decoding.
+- Compact communications. Detachable Cadence type information allows CCF-based protocols to optionally avoid resending the same Cadence type information for all messages matching that type. CCF-based protocols can cache and uniquely identify a Cadence type so it can be matched to a Cadence value (such as an event) during decoding.
 
 - Deterministic encoding. CCF uses CBOR's Preferred Serialization to achieve deterministic encoding. Other parts of CBOR's Core Deterministic Encoding Requirements are not needed by this specification.
 
-- Early detection of malformed data. CCF decoders can detect and reject malformed data without creating Cadence objects. CCF decoders can detect malformed data without having Cadence type info. If data is not malformed, then CCF decoders can proceed to detect and reject invalid CCF data as described in this document.
+- Early detection of malformed data. CCF decoders can detect and reject malformed data without creating Cadence objects. CCF decoders can detect malformed data without having Cadence type information. If data is not malformed, then CCF decoders can proceed to detect and reject invalid CCF data as described in this document.
 
-- Extensibility. CCF encodes composite type information in a header (separate from data). Data refers to composite types by unique type ID, encoded as bytes. In the future, composite type information can be stored on-chain and header isn't necessary to be sent with data. Type ID can be an universal counter or hash value.
+- Extensibility. CCF encodes composite type information in a header (separate from data). Data refers to composite types by unique type ID, encoded as bytes. If the composite type information can be stored on-chain, the header won't need to be sent with the data. Type ID can be a universal counter, hash digest, or other unique identifier specified by CCF-based protocols.
 
 - Interoperability and Reuse. CCF uses the same approach taken by COSE (RFC 9052) leveraging CBOR (RFC 8949). CCF leverages CBOR, which allows CCF codecs to use CBOR codecs under the hood.
 
@@ -80,7 +82,9 @@ CCF is designed to support:
 
 ### Why CBOR
 
-CBOR is an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) defined by [IETF&nbsp;STD&nbsp;94 (RFC 8949)](https://www.rfc-editor.org/info/std94):
+CBOR is a binary data format specified by [RFC 8949](https://www.rfc-editor.org/info/std94) and designated by IETF as an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) (STD&nbsp;94).
+
+Design goals of CBOR balances trade-offs, making it useful as a building block for new formats and protocols:
 
 > The Concise Binary Object Representation (CBOR) is a data format
    whose design goals include the possibility of extremely small code
@@ -88,7 +92,9 @@ CBOR is an [Internet Standard](https://www.ietf.org/rfc/std-index.txt) defined b
    for version negotiation. These design goals make it different from
    earlier binary serializations such as ASN.1 and MessagePack.
 
-In addition to the aspects listed in CBOR's design goals, CBOR-based formats can support:
+CBOR is used by data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
+
+Notably, CBOR-based data formats like CCF can be specified to support:
 - Deterministic encodings across programming languages. Encoders implemented in different languages can produce identical deterministic encodings.
 - Separate detection of malformed data and invalid data. Decoders can efficiently reject malformed inputs without creating Cadence objects.
 
@@ -97,34 +103,21 @@ CBOR is well-suited to replace JSON in data formats and protocols. CBOR's data m
 - extension points (CBOR Tags and Simple Values)
 - deterministic encoding (Core Deterministic Encoding Requirements)
 
-Published comparisons between CBOR and other binary data formats such as Protocol Buffers, etc. include:
+Published comparisons between CBOR and other binary data formats, such as Protocol Buffers, etc., include:
 - Appendix C of RFC 8618 Compacted-DNS: [Comparison of Binary Formats](https://www.rfc-editor.org/rfc/rfc8618#appendix-C)
 - Appendix E of RFC 8949 (STD 94) CBOR: [Comparison of Other Binary Formats to CBOR's Design Objectives](https://www.rfc-editor.org/rfc/rfc8949.html#name-comparison-of-other-binary-)
 
-CBOR is used in data formats and protocols such as [W3C&nbsp;WebAuthn](https://www.w3.org/TR/webauthn-2/), Compacted-DNS&nbsp;([IETF&nbsp;RFC&nbsp;8618](https://www.rfc-editor.org/rfc/rfc8618.html)), COSE&nbsp;([IETF&nbsp;STD&nbsp;96](https://www.rfc-editor.org/info/std96)), CWT&nbsp;([IETF&nbsp;RFC&nbsp;8392](https://www.rfc-editor.org/info/rfc8392)), etc.
+Although using a 100% custom data format can sometimes produce smaller encodings than CBOR, that alone doesn't outweigh the combination of other qualities and considerations such as maturity of specification, security, maintainability, risks, etc.
 
-Although using a 100% custom data format can sometimes produce smaller encodings than CBOR, that alone doesn't outweigh the combination of other qualities and considerations such as security, maintainability, risks, etc.
-
-Lastly, Cadence is [already using CBOR](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) to encode internal values, so using CBOR to encode external values added to the list of stronger reasons making CBOR a good fit.
-
-Other considerations for using CBOR include availability and quality of CBOR codecs in various programming languages.
+Other considerations for using CBOR include the availability and quality of CBOR codecs in various programming languages.
 
 ### Interoperability and Reuse of CBOR Codecs
 
-CBOR data can be exchanged between standards compliant CBOR codecs implemented in any programming language.
-
-CBOR-based formats and protocols can use existing CBOR codecs. For example, [CCF codec](https://github.com/onflow/cadence/tree/master/encoding/ccf) in Cadence uses [fxamacker/cbor](https://github.com/fxamacker/cbor):
-  - `fxamacker/cbor` was designed with security in mind and passed multiple security assessments in 2022. A [nonconfidential security assessment](https://github.com/veraison/go-cose/blob/v1.0.0-rc.1/reports/NCC_Microsoft-go-cose-Report_2022-05-26_v1.0.pdf) produced by NCC Group for Microsoft Corporation includes parts of fxamacker/cbor.
-  - `fxamacker/cbor` is used in projects by Arm Ltd., Cisco, EdgeX&nbsp;Foundry, Flow Foundation, Fraunhofer&#8209;AISEC, IBM, Kubernetes, Linux&nbsp;Foundation, Microsoft, Mozilla, Tailscale, Teleport, [and&nbsp;others](https://github.com/fxamacker/cbor#who-uses-fxamackercbor). Notably, it was already [used by Cadence](https://github.com/onflow/cadence/blob/master/runtime/interpreter/encode.go) for internal value encoding.
-  - `fxamacker/cbor` is maintained by the author of this document.
-
-CBOR codecs are available in various programming languages. Examples include:
-
-- __.NET Languages__: Microsoft maintains [System.Formats.Cbor](https://learn.microsoft.com/en-us/dotnet/api/system.formats.cbor), the CBOR codec in .Net Platform Extensions.
-- __C/C++__: Intel maintains [TinyCBOR](https://github.com/intel/tinycbor), a CBOR codec optimized for very fast operation with very small footprint.
-- __Javascript__: Joe Hildebrand (former VP of Engineering at Mozilla) maintains [hildji/cbor2](https://github.com/hildjj/cbor2).
+CBOR data can be exchanged between standards-compliant CBOR codecs implemented in any programming language.
 
 Projects implementing a CCF codec should evaluate more than one CBOR codec for standards compliance, security, and other factors.
+
+When evaluating or comparing codecs, benchmarks should include decoding malicious data.
 
 ### Terminology
 
@@ -132,18 +125,18 @@ This specification uses requirements terminology, CBOR terminology, and CDDL ter
 
 This specification also uses the following notations:
 - Concise Data Definition Language (CDDL) defined by [RFC 8610](https://www.rfc-editor.org/rfc/rfc8610.html). CDDL is a notation for unambiguously expressing CBOR and JSON data structures.
-- Extended Diagnostic Notation (EDN) defined by [Appendix G of RFC 8610](https://www.rfc-editor.org/rfc/rfc8610.html#appendix-G). EDN is a "diagnostic notation" used for conversing about encoded CBOR data items.
+- Extended Diagnostic Notation (EDN) defined by [Appendix G of RFC 8610](https://www.rfc-editor.org/rfc/rfc8610.html#appendix-G). EDN is a "diagnostic notation" used to converse about encoded CBOR data items.
 
 #### Requirements Terminology
 
-The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in BCP 14 [[RFC2119](https://www.rfc-editor.org/info/rfc2119)] [[RFC8174](https://www.rfc-editor.org/info/rfc8174)] when, and only when, they appear in all capitals, as shown here.
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [BCP 14](https://www.rfc-editor.org/info/bcp14) [[RFC2119](https://www.rfc-editor.org/info/rfc2119)] [[RFC8174](https://www.rfc-editor.org/info/rfc8174)] when, and only when, they appear in all capitals, as shown here.
 
 #### CBOR Terminology
 
 This specification uses this subset of CBOR data items as defined in RFC 8949:
 - nil
 - bool
-- positive integer
+- unsigned integer
 - negative integer
 - byte string
 - text string
@@ -165,9 +158,9 @@ This specification uses CDDL notation to express CBOR data items:
 - `(Foo)`: Foo is a group
 - `Foo / Bar`: either Foo or Bar
 - `Foo Bar`: Foo followed by Bar
-- `[+ Foo]`: one or more Foo in CBOR array
-- `[* Foo]`: zero or more Foo in CBOR array
-- `#6.nnn(type)`: CBOR tag with tag number nnn and content type of "type".
+- `[+ Foo]`: one or more Foo in a CBOR array
+- `[* Foo]`: zero or more Foo in a CBOR array
+- `#6.nnn(type)`: CBOR tag with tag number nnn and content type of "type"
 
 ## Serialization Considerations
 
@@ -182,30 +175,30 @@ CCF is a data format that uses a subset of CBOR with additional requirements for
 - `let aoa: [AnyStruct] = ["hello", true]` declares `aoa` of type `[AnyStruct]`.
 
 CCF encoding decouples value encoding from type encoding. For example:
-- Cadence booleans is encoded as a tuple of type and value: the `Bool` type and its value.
-- Cadence strings is encoded as a tuple of type and value: the `String` type and its value.
+- Cadence boolean is encoded as a tuple of type and value: the `Bool` type and its value.
+- Cadence string is encoded as a tuple of type and value: the `String` type and its value.
 
 For compactness, encoders can omit encodings of Cadence type when:
 - Optional value is nil, provided that the optional type information is encoded in the outer container.
 - Element's type matches the outer container's element type.
 
 For example, when encoding a Cadence container such as `Array`:
-- `[String]`: each element's type matches the outer container's element type, so encoders can omit encoding each element's type.
+- `[String]`: each element's type matches the outer container's element type, so encoders can omit each element's type.
 - `[AnyStruct]`: each element's type cannot match the outer container's element type, so encoders must encode the type for each element.
 
 ### Valid CCF Encoding Requirements
 
-A CCF encoding is valid if it complies with "Valid CCF Encoding Requirements".
+A CCF encoding is valid if it complies with "Valid CCF Encoding Requirements."
 
-Encoders MUST produce valid CCF encodings from valid input items. Encoders are not required to check for invalid input items (e.g. invalid UTF-8 strings, duplicate dictionary keys, etc.) Applications MUST NOT provide invalid items to encoders.
+Encoders MUST produce valid CCF encodings from valid input items. Encoders are not required to check for invalid input items (e.g., invalid UTF-8 strings, duplicate dictionary keys, etc.) Applications MUST NOT provide invalid items to encoders.
 
 Decoders MUST reject CCF encodings that are not valid unless otherwise specified in this section.
 
 A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies with the following restrictions:
 
-- CBOR data items MUST be well-formed and valid as defined in RFC 8949. E.g. CBOR text strings MUST contain valid UTF-8. As an exception, RFC 8949 requirements for CBOR maps are not applicable because CCF does not use CBOR maps.
+- CBOR data items MUST be well-formed and valid as defined in RFC 8949. For example, CBOR text strings MUST contain valid UTF-8. As an exception, RFC 8949 requirements for CBOR maps are not applicable because CCF does not use CBOR maps.
 
-- CCF encodings must comply with specifications in "CCF Specified in CDDL Notation" section of this document.
+- CCF encodings MUST comply with specifications in "CCF Specified in CDDL Notation" section of this document.
 
 - `composite-type.id` MUST be unique in `ccf-typedef-message` or `ccf-typedef-and-value-message`.
 
@@ -223,7 +216,7 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 - `name` MUST be unique in `function-value.type-parameters`. 
 
-- All parameter lists MUST have unique `identifier`. For example, `indentifier` MUST be unique in
+- All parameter lists MUST have a unique `identifier`. For example, `identifier` MUST be unique in
   - `composite-type-value.initializers`
   - `function-value.parameters`
 
@@ -235,11 +228,13 @@ A CCF encoding complies with "Valid CCF Encoding Requirements" if it complies wi
 
 ### Deterministic CCF Encoding Requirements
 
-A CCF encoding is deterministic if it satisfies the "Deterministic CCF Encoding Requirements".
+A CCF encoding is deterministic if it satisfies the "Deterministic CCF Encoding Requirements."
 
-Encoders SHOULD emit CCF encodings that are deterministic. CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings. For example:
-- a CCF-based protocol for encoding transaction arguments might want to specify that encoders MUST produce deterministic encodings of the values.
-- a CCF-based protocol for encoding unsorted fields might want to specify that encoders are not required to produce deterministic encodings of the values (if compatibility with legacy systems is higher priority than "Deterministic CCF Encoding Requirements"). 
+Encoders SHOULD emit deterministic CCF encodings.  However, some CCF-based protocols may not require deterministic CCF encodings.
+
+CCF-based protocols MUST specify when encoders are required to emit deterministic CCF encodings. For example:
+- A CCF-based protocol for encoding transaction arguments might want to specify that encoders MUST produce deterministic encodings of the values.
+- A CCF-based protocol for encoding unsorted fields might want to specify that encoders are not required to produce deterministic encodings of the values (if compatibility with legacy systems is a higher priority than "Deterministic CCF Encoding Requirements"). 
 
 Decoders SHOULD check CCF encodings to determine whether they are deterministic encodings. CCF-based protocols MUST specify when decoders are required to check for deterministic encodings and how to handle nondeterministic encodings.
 
@@ -253,7 +248,7 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
 
 - `composite-type-value.id` MUST be identical to the zero-based encoding order `type-value`.
 
-- `inline-type-and-value` MUST NOT be used when type can be omitted as described in "Cadence Types and Values Encoding".
+- `inline-type-and-value` MUST NOT be used when type can be omitted as described in "Cadence Types and Values Encoding."
 
 - The following data items MUST be sorted using bytewise lexicographic order of their deterministic encodings:
   - Type definitions MUST be sorted by `cadence-type-id` in `composite-typedef`.
@@ -270,10 +265,10 @@ A CCF encoding satisfies the "Deterministic CCF Encoding Requirements" if it sat
 CBOR security considerations in [Section 10 of RFC 8949 (CBOR)](https://www.rfc-editor.org/rfc/rfc8949.html#name-security-considerations) apply to CCF.
 
 There are two types of checks for acceptable data:
-- Checks for well-formedness
-- Checks for validity
+- well-formedness
+- validity
 
-CBOR defines data [well-formedness](https://www.rfc-editor.org/rfc/rfc8949.html#name-well-formedness-errors-and-) and a CBOR decoder MUST detect and reject malformed data before checking for validity.
+CBOR defines data [well-formedness](https://www.rfc-editor.org/rfc/rfc8949.html#name-well-formedness-errors-and-), and a CBOR decoder MUST detect and reject malformed data before checking for validity.
 
 CCF decoders MUST detect and reject malformed data before checking for validity.
 
@@ -282,15 +277,15 @@ CCF decoders SHOULD detect and reject malformed data before creating Cadence obj
 CCF decoders can handle invalid CCF messages as required by each CCF-based protocol. In some cases, it may be more practical for the application to check if the decoded data is acceptable.
 
 CCF decoders SHOULD allow CBOR limits to be specified and enforced, such as:
-- Max number of array elements
-- Max number of map pairs
-- Max nested levels
+- maximum number of array elements
+- maximum number of map pairs
+- maximum nested levels
 
-For example, max number of array elements would forbid any single array in a CCF message from exceeding that many elements.
+For example, the maximum number of array elements would forbid any single array in a CCF message from exceeding that many elements.
 
 The main trade-off for decoder limits:
-- limits set too high can allow memory exhaustion and other attacks to succeed.
-- limits set too low creates the possibility of being unable to decode non-malicious messages that exceeds limits.
+- Limits set too high can allow memory exhaustion and other attacks to succeed.
+- Limits set too low create the possibility of being unable to decode non-malicious messages that exceed limits.
 
 Encoders usually don't enforce limits because it's simpler and more efficient for applications to enforce limits before providing the data to encoders.
 
@@ -300,13 +295,13 @@ Examples of JSON are in JSON-Cadence Data Interchange Format:
 - Minified JSON encoding size is used for comparisons.
 - Non-minified JSON encoding is shown for readability.
 
-Examples of CCF encoded data are shown in hex or Extended Diagnostic Notation (EDN) for readability.
+Examples of CCF-encoded data are shown in hex or Extended Diagnostic Notation (EDN) for readability.
 
-For more info about EDN, see [Appendix G of RFC 8610 (CDDL)](https://www.rfc-editor.org/rfc/rfc8610.html#appendix-G).
+For more information about EDN, see [Appendix G of RFC 8610 (CDDL)](https://www.rfc-editor.org/rfc/rfc8610.html#appendix-G).
 
 ### Cadence Simple Type Value
 
-Cadence `Int` type with value `42` encoded to JSON is 27 bytes when minified.
+Cadence `Int` type with value `42` encoded to minified JSON is 27 bytes:
 
 ```json
 {
@@ -322,12 +317,12 @@ d88282d88904c2412a
 ```
 
 It represents `130([137(4), 42])`, where:
-- `137(4)` is Cadence `Int`.
-- `42` is raw value.
+- `137(4)` is the Cadence `Int`.
+- `42` is the raw value.
 
 ### Cadence Homogeneous Array with Simple Type Elements
 
-Cadence `[Int]` type of value `[1, 2, 3]` encoded to JSON is 107 bytes when minified:
+Cadence `[Int]` type of value `[1, 2, 3]` encoded to minified JSON is 107 bytes:
 
 ```json
 {
@@ -356,12 +351,12 @@ d88282d88bd8890483c24101c24102c24103
 ```
 
 It represents `130([139(137(4)), [1, 2, 3]])`, where:
-- `139(137(4))` is Cadence array of `Int`.
-- `[1, 2, 3]` is raw value.
+- `139(137(4))` is the Cadence array of `Int`.
+- `[1, 2, 3]` is the raw value.
 
 ### Cadence Heterogeneous Array with Simple Type Elements
 
-Cadence `[AnyStruct]` type of value `[1, "a", true]` encoded to JSON is 112 bytes when minified:
+Cadence `[AnyStruct]` type of value `[1, "a", true]` encoded to minified JSON is 112 bytes:
 
 ```json
 {
@@ -390,18 +385,18 @@ d88282d88bd889182783d88282d88904c24101d88282d889016161d88282d88900f5
 ```
 
 It represents `130([139(137(39)), [130([137(4), 1]), 130([137(1), "a"]), 130([137(0), true])]])`, where:
-- `139(137(39))` is Cadence array of `AnyStruct`.
-- `130([137(4), 1])` is first element (`137(4)` is Cadence `Int`, `1` is raw value).
-- `130([137(1), "a"])` is second element (`137(1)` is Cadence `String`, `"a"` is raw value).
-- `130([137(0), true]` is third element (`137(0)` is Cadence `Boolean`, `true` is raw value).
+- `139(137(39))` is the Cadence array of `AnyStruct`.
+- `130([137(4), 1])` is the first element (`137(4)` is the Cadence `Int`, `1` is the raw value).
+- `130([137(1), "a"])` is the second element (`137(1)` is the Cadence `String`, `"a"` is the raw value).
+- `130([137(0), true]` is the third element (`137(0)` is the Cadence `Boolean`, `true` is the raw value).
 
 ### Cadence Homogeneous Array with Composite Type Elements
 
 This example is for CCF in fully self-describing mode (partially self-describing mode encodes smaller messages).
 
-Cadence composite types, such as struct, resource, and event, are not inlined as type info. Each encoded composite type info has a unique ID which is used to bind with Cadence value.
+Cadence composite types, such as struct, resource, and event, are not inlined as type information. Each encoded composite type information has a unique ID that is used to bind with a Cadence value.
 
-Cadence `[Foo]` type encoded to JSON is 353 bytes when minified:
+Cadence `[Foo]` type encoded to minified JSON is 353 bytes:
 
 ```json
 {
@@ -465,13 +460,13 @@ d8818281d8a183406a532e746573742e466f6f818263626172d8890482d88bd888408381c2410181
 It represents `129([[161([h'', "S.test.Foo", [["bar", 137(4)]]])], [139(136(h'')), [[1], [2], [3]]]])`, which contains type and value.
 
 Type data item represents `161([h'', "S.test.Foo", [["bar", 137(4)]]])` , which defines a resource type:
-- `h''` is CCF type ID `0`. This ID is used inside value data item to bind type with raw value.
-- `"S.test.Foo"` is Cadence type ID.
-- `[["bar", 137(4)]]` is field definition of one field: `"bar"` field of Cadence `Int`.
+- `h''` is CCF type ID `0`. This ID is used inside the value data item to bind the type with the raw value.
+- `"S.test.Foo"` is the Cadence type ID.
+- `[["bar", 137(4)]]` is the field definition of the `"bar"` field of Cadence `Int`.
 
 Value data item represents `[139(136(h'')), [[1], [2], [3]]]]`, where:
-- `139(136(h''))` is Cadence array of type identified by ID `0`.
-- `[[1], [2], [3]]]` is array of `Foo` resource raw field data.
+- `139(136(h''))` is the Cadence array of the type identified by ID `0`.
+- `[[1], [2], [3]]]` is the array of raw field data of the `Foo` resource.
 
 ### Cadence Homogeneous Array with Composite Type Elements (One Field Type Is Abstract)
 
@@ -479,7 +474,7 @@ This example is for CCF in fully self-describing mode (partially self-describing
 
 Composite field `baz` is abstract type.
 
-Cadence `[Foo]` type encoded to JSON is 508 bytes when minified:
+Cadence `[Foo]` type encoded to minified JSON is 508 bytes:
 
 ```json
 {
@@ -564,22 +559,22 @@ d8818281d8a183406a532e746573742e466f6f828263626172d88904826362617ad889182782d88b
 It represents `129([[161([h'', "S.test.Foo", [["bar", 137(4)], ["baz", 137(39)]]])], [139(136(h'')), [[1, 130([137(4), 1])], [2, 130([137(1), "a"])], [3, 130([137(0), true])]]]])`, which contains type and value.
 
 Type data item represents `161([h'', "S.test.Foo", [["bar", 137(4)], ["baz", 137(39)]]])` , which defines a resource type:
-- `h''` is CCF type ID `0`. This ID is used inside value data item to bind type with raw value.
-- `"S.test.Foo"` is Cadence type ID.
-- `["bar", 137(4)]` is first field definition: `"bar"` field of Cadence `Int`.
-- `["baz", 137(39)]` is second field definition: `"baz"` field of Cadence `AnyStruct`.
+- `h''` is CCF type ID `0`. This ID is used inside the value data item to bind the type with the raw value.
+- `"S.test.Foo"` is the Cadence type ID.
+- `["bar", 137(4)]` is the first field: `"bar"` field of Cadence `Int`.
+- `["baz", 137(39)]` is the second field: `"baz"` field of Cadence `AnyStruct`.
 
 Value data item represents `[139(136(h'')), [[1, 130([137(4), 1])], [2, 130([137(1), "a"])], [3, 130([137(0), true])]]]`, where:
-- `139(136(h''))` is Cadence array of type identified by ID `0`.
-- `[1, 130([137(4), 1])]` is first resource raw field data.
-- `[2, 130([137(1), "a"])]` is second resource raw field data.
-- `[3, 130([137(0), true])]` is third resource raw field data.
+- `139(136(h''))` is the Cadence array of the type identified by ID `0`.
+- `[1, 130([137(4), 1])]` is the raw field data of the first resource.
+- `[2, 130([137(1), "a"])]` is the raw field data of the second resource.
+- `[3, 130([137(0), true])]` is the raw field data of the third resource.
 
 ### `FeesDeducted` Event
 
-This example is for CCF in fully self-describing mode (partially self-describing mode encodes smaller messages).
+This example is for CCF in fully self-describing mode partially self-describing mode encodes smaller messages).
 
-This example of `FeesDeducted` event encoded to JSON is 298 bytes when minified:
+Cadence `FeesDeducted` event encoded to minified JSON is 298 bytes:
 
 ```json
 {
@@ -622,33 +617,33 @@ d8818281d8a283407828412e663931396565373734343762373439372e466c6f77466565732e4665
 It represents `129([[162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]])], [136(h''), [2969, 575, 100000000]]])`, which contains type and value.
 
 Type data item represents `162([h'', "A.f919ee77447b7497.FlowFees.FeesDeducted", [["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]])` , which defines an event type:
-- `h''` is CCF type ID `0`. This ID is used inside value data item to bind type with raw value.
-- `"A.f919ee77447b7497.FlowFees.FeesDeducted"` is Cadence type ID.
+- `h''` is CCF type ID `0`. This ID is used inside the value data item to bind the type with the raw value.
+- `"A.f919ee77447b7497.FlowFees.FeesDeducted"` is the Cadence type ID.
 - `[["amount", 137(23)], ["executionEffort", 137(23)], ["inclusionEffort", 137(23)]]` is field definition with 3 fields: `"amount"` field of Cadence `UFix64`, `"inclusionEffort"` field of Cadence `UFix64`, and `"executionEffort"` field of Cadence `UFix64`. Fields are sorted by field name.
 
 Value data item represents `[136(h''), [2969, 575, 100000000]]`, where:
-- `136(h'')` is type identified by ID `0`.
+- `136(h'')` is the type identified by ID `0`.
 - `[2969, 575, 100000000]` is `FeesDeducted` event raw field data.
 
 ## Specifications
 
-There are 3 top level CCF messages: `ccf-typedef-message`, `ccf-typedef-and-value-message`, and `ccf-type-and-value-message`.
+There are 3 top-level CCF messages: `ccf-typedef-message`, `ccf-typedef-and-value-message`, and `ccf-type-and-value-message`.
 
 - `ccf-typedef-message` is a list of type definitions for Cadence composite types.
 - `ccf-typedef-and-value-message` is a Cadence value preceded by a list of type definitions of referenced Cadence composite types.
-- `ccf-type-and-value-message` is a Cadence value preceded by builtin or known composite Cadence type(s).
+- `ccf-type-and-value-message` is a Cadence value preceded by built-in or known composite Cadence type(s).
 
 Cadence types are encoded as `inline-type` (inlined) or as `composite-typedef` (not inlined).
 
-Cadence data is encoded depending on its type. For example, Cadence `UInt8` is encoded as CBOR positive integer, Cadence `String` is encoded as CBOR text string, Cadence `Address` is encoded as CBOR byte string, and Cadence struct data is encoded as an array of its raw field data.
+Cadence data is encoded depending on its type. For example, Cadence `UInt8` is encoded as a CBOR unsigned integer, Cadence `String` is encoded as a CBOR text string, Cadence `Address` is encoded as a CBOR byte string, and Cadence struct data is encoded as an array of its raw field data.
 
 ### Cadence Types and Type Values
 
 Cadence types and Cadence type values (run-time types) are encoded differently. They contain different data because they are used differently.
 
-Cadence types are used to decode Cadence data, so they only contain information needed for decoding. For example, composite type's field info is needed to decode composite value. However, interface type's field info isn't needed to decode values implementing interface type.
+Cadence types are used to decode Cadence data, so they only contain information needed for decoding. For example, field information of a composite type is needed to decode the composite value. However, field information of an interface type isn't needed to decode values implementing the interface type.
 
-Cadence type value is a Cadence value which provides comprehensive information about a type. For example, composite type value and interface type value contain info about both fields and initializers.
+Cadence type value is a Cadence value which provides comprehensive information about a type. For example, composite type value and interface type value contain information about both fields and initializers.
 
 ### CCF Specified in CDDL Notation
 
@@ -776,7 +771,7 @@ composite-type = [
     ]
 ]
 
-; interface-type doesn't include field info because it's not needed for
+; interface-type doesn't include field information because it's not needed for
 ; decoding values implementing interface type.
 interface-type = [
     id: id,


### PR DESCRIPTION
I recently started updating https://github.com/onflow/ccf (in PR 7) to improve readability, explicitly state some things that might not be obvious to all readers, and fix grammar.

This syncs with latest commit in that PR (as of March 27, 2025).

Next, I'm going to update the "CCF Examples" section to be clearer.
